### PR TITLE
Integrate GLSL mesh shader for mesh rendering

### DIFF
--- a/data/meshFrag.glsl
+++ b/data/meshFrag.glsl
@@ -1,0 +1,17 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform float u_time;
+
+varying vec4 vertColor;
+varying vec3 vertNormal;
+
+void main() {
+  vec3 n = normalize(vertNormal);
+  float lighting = max(0.0, n.z);
+  float pulse = 0.5 + 0.5 * sin(u_time);
+  vec3 col = vertColor.rgb * lighting * pulse;
+  gl_FragColor = vec4(col, vertColor.a);
+}

--- a/data/meshVert.glsl
+++ b/data/meshVert.glsl
@@ -1,0 +1,18 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform mat4 transform;
+attribute vec4 position;
+attribute vec4 color;
+attribute vec3 normal;
+
+varying vec4 vertColor;
+varying vec3 vertNormal;
+
+void main() {
+  vertColor = color;
+  vertNormal = normal;
+  gl_Position = transform * position;
+}

--- a/maevegestalt.pde
+++ b/maevegestalt.pde
@@ -7,7 +7,7 @@ import wblut.processing.*;
 import peasy.*; 
 import java.util.*; 
 import controlP5.*; 
-import com.jogamp.newt.event.KeyEvent; 
+import com.jogamp.newt.event.KeyEvent;
 
 WB_Render render;
 HE_MeshCollection meshColl;
@@ -26,6 +26,7 @@ color creationCol = #456F76;
 
 ControlP5 cp5;
 PFont font10;
+PShader meshShader;
 
 public void setup() {
   //fullScreen(P3D);
@@ -37,6 +38,8 @@ public void setup() {
   cam.setResetOnDoubleClick(false);
 
   render = new WB_Render(this);
+
+  meshShader = loadShader("meshFrag.glsl", "meshVert.glsl");
 
   selectedColl = new HE_MeshCollection();
 
@@ -87,8 +90,10 @@ public void draw() {
   scale(1);
   if(creationMode) fill(creationCol);
   else fill(30);
-
+  meshShader.set("u_time", millis()/1000.0f);
+  shader(meshShader);
   render.drawFaces(meshColl);
+  resetShader();
 
   noFill();
   stroke(255);


### PR DESCRIPTION
## Summary
- Add vertex and fragment shaders for mesh rendering with time-based pulse lighting
- Load and apply shader in sketch to enable GPU-driven effects

## Testing
- `processing-java --sketch=. --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a57da443e4832598e141a496b2945f